### PR TITLE
Don't use php shorttags

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -61,30 +61,30 @@ if(property_exists($this, 'include_facebook')) {
     <div class="nav">
       <ul class="nav navbar-nav">
 
-        <? if(session('me')) { ?>
+        <?php if(session('me')) { ?>
           <li><a href="/editor">Editor</a></li>
           <li><a href="/new">Note</a></li>
           <li><a href="/bookmark">Bookmark</a></li>
           <li><a href="/favorite">Favorite</a></li>
           <li><a href="/photo">Photo</a></li>
           <li><a href="/email">Email</a></li>
-        <? } ?>
+        <?php } ?>
 
         <li><a href="/docs">Docs</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        <? if(session('me')) { ?>
+        <?php if(session('me')) { ?>
           <li><a href="/settings"><?= preg_replace(array('/https?:\/\//','/\/$/'),'',session('me')) ?></a></li>
           <li><a href="/signout">Sign Out</a></li>
-        <? } else if(property_exists($this, 'authorizing')) { ?>
+        <?php } else if(property_exists($this, 'authorizing')) { ?>
           <li class="navbar-text"><?= $this->authorizing ?></li>
-        <? } else { ?>
+        <?php } else { ?>
           <form action="/auth/start" method="get" class="navbar-form">
             <input type="text" name="me" placeholder="yourdomain.com" class="form-control" />
             <button type="submit" class="btn">Sign In</button>
             <input type="hidden" name="redirect_uri" value="https://<?= $_SERVER['SERVER_NAME'] ?>/indieauth" />
           </form>
-        <? } ?>
+        <?php } ?>
 
       </ul>
     </div>

--- a/views/photo.php
+++ b/views/photo.php
@@ -17,7 +17,7 @@
 
         <div class="form-group">
           <label for="note_content"><code>content</code> (optional)</label>
-          <textarea name="note_content" id="note_content" value="" class="form-control" style="height: 4em;"><? if(isset($this->note_content)) echo $this->note_content ?></textarea>
+          <textarea name="note_content" id="note_content" value="" class="form-control" style="height: 4em;"><?php if(isset($this->note_content)) echo $this->note_content ?></textarea>
         </div>
 
         <button class="btn btn-success" id="btn_post">Post</button>
@@ -25,22 +25,22 @@
         <div style="clear:both;"></div>
       </form>
 
-      <? if(!empty($this->location)): ?>
+      <?php if(!empty($this->location)): ?>
         <div class="alert alert-success">
           <strong>Success!</strong> Photo posted to: <em><a href="<?= $this->location ?>"><?= $this->location ?></a></em>
         </div>
-      <? endif ?>
+      <?php endif ?>
 
-      <? if(!empty($this->error)): ?>
+      <?php if(!empty($this->error)): ?>
         <div class="alert alert-danger">
           <strong>Error:</strong> <em><?= $this->error ?></em>
         </div>
-      <? endif ?>
+      <?php endif ?>
 
-      <? if(!empty($this->response)): ?>
+      <?php if(!empty($this->response)): ?>
         <h4>Response:</h4>
         <pre><?= $this->response ?></pre>
-      <? endif ?>
+      <?php endif ?>
   </div>
   <script>
   $(function(){


### PR DESCRIPTION
The "other fix" I mentioned in #24 – this remoces shorttags. Reason is that PHP shorttags aren't enabled by default and is also by at least some people recommended to avoid. Therefore things didn't work out that well at the beginning with Quill for me. I could of course change my PHP.ini, but not everyone can or know how to do it – so better just avoid shorttags.