### PR TITLE
Explicitly define $dbType for default MySQL config

### DIFF
--- a/lib/config.template.php
+++ b/lib/config.template.php
@@ -5,6 +5,7 @@ class Config {
   public static $gaid = '';
 
   // MySQL (default)
+  public static $dbType = 'mysql';
   public static $dbHost = '127.0.0.1';
   public static $dbName = 'quill';
   public static $dbUsername = 'quill';


### PR DESCRIPTION
The `helper.php` checks for the `dbType` property on the 
`Config` class. Since nothing is defined it throws:

```
Fatal error: Access to undeclared static property: 
Config::$dbType in …/Quill/lib/helpers.php on line 3
```