### PR TITLE
Add fullscreen meta tags for Safari and Chrome

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -27,6 +27,10 @@
 
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#428bca">
+
     <script src="/js/jquery-1.7.1.min.js"></script>
     <script src="/js/script.js"></script>
     <script src="/js/date.js"></script>


### PR DESCRIPTION
Also set the theme color for Chrome to the blue used
in the logo.