### PR TITLE
Use Tokenfield to break up the input (fixes #95)

### DIFF
--- a/views/new-post.php
+++ b/views/new-post.php
@@ -689,7 +689,7 @@ $(function(){
       syndications.push($(btn).data('syndicate-to'));
     });
 
-    var category = csv_to_array($("#note_category").val());
+    var category = $("#note_category").tokenfield("getTokens");
 
     var formData = new FormData();
     var entry = {};


### PR DESCRIPTION
The csv_to_array function breaks on commas *and* spaces, but the Tokenfield-based UI is set up so that tags may contain spaces. Fortunately Tokenfield includes a function to break the field into an array for you, so I just used that function instead.

(This patch has not been tested.)