### PR TITLE
Add new weight posting interface

### DIFF
--- a/controllers/controllers.php
+++ b/controllers/controllers.php
@@ -382,6 +382,9 @@ $app->post('/settings/save', function() use($app) {
         $user->micropub_syndicate_field = $params['syndicate_field'];
     }
 
+    if(array_key_exists('weight_unit', $params) && $params['weight_unit'])
+      $user->weight_unit = $params['weight_unit'];
+
     $user->save();
     $app->response()['Content-type'] = 'application/json';
     $app->response()->body(json_encode(array(
@@ -884,5 +887,47 @@ $app->get('/airport-info', function() use($app){
 
     $app->response()['Content-type'] = 'application/json';
     $app->response()->body(json_encode($response));
+  }
+});
+
+function create_weight(&$user, $weight_num, $weight_unit) {
+  $micropub_request = array(
+    'type' => ['h-entry'],
+    'properties' => [
+      'weight' => [[
+        'type' => ['h-measure'],
+        'properties' => [
+          'num' => [$weight_num],
+          'unit' => [$weight_unit]
+        ]
+      ]]
+    ]
+  );
+  $r = micropub_post_for_user($user, $micropub_request, null, true);
+
+  return $r;
+}
+
+$app->get('/weight', function() use($app){
+  if($user=require_login($app)) {
+    render('new-weight', array(
+      'title' => 'New Weight',
+      'unit' => $user->weight_unit
+    ));
+  }
+});
+
+$app->post('/weight', function() use($app) {
+  if($user=require_login($app)) {
+    $params = $app->request()->params();
+
+    $r = create_weight($user, $params['weight_num'], $user->weight_unit);
+    $location = $r['location'];
+
+    $app->response()['Content-type'] = 'application/json';
+    $app->response()->body(json_encode(array(
+      'location' => $location,
+      'error' => $r['error']
+    )));
   }
 });

--- a/schema/migrations/0011.sql
+++ b/schema/migrations/0011.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN `weight_unit` VARCHAR(255) DEFAULT 'kg';

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -24,5 +24,6 @@ CREATE TABLE `users` (
   `default_timezone` varchar(255) DEFAULT NULL,
   `supported_post_types` longtext,
   `supported_visibility` longtext,
+  `weight_unit` varchar(255) DEFAULT 'kg',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -23,5 +23,6 @@ CREATE TABLE users (
   email_username TEXT,
   default_timezone TEXT,
   supported_post_types TEXT,
-  supported_visibility TEXT
+  supported_visibility TEXT,
+  weight_unit TEXT default 'kg'
 );

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -18,6 +18,9 @@
       <?php if(supports_post_type($this->user, 'like')): ?>
         <li><a href="/favorite">👍</a></li>
       <?php endif; ?>
+      <?php if(supports_post_type($this->user, 'weight')): ?>
+        <li><a href="/weight">⚖️</a></li>
+      <?php endif; ?>
       <?php if(supports_post_type($this->user, 'repost')): ?>
         <li><a href="/repost">♺</a></li>
       <?php endif; ?>

--- a/views/new-weight.php
+++ b/views/new-weight.php
@@ -1,0 +1,52 @@
+  <div class="narrow">
+    <?= partial('partials/header') ?>
+
+      <div style="clear: both;" class="notice-pad">
+        <div class="alert alert-success hidden" id="test_success"><strong>Success! </strong><a href="" id="post_href">View your post</a></div>
+        <div class="alert alert-danger hidden" id="test_error"><strong>Something went wrong!</strong><br>Your Micropub endpoint indicated that something went wrong creating the post.</div>
+      </div>
+
+      <form style="margin-top: 20px;" id="weight_form">
+
+        <div class="form-group">
+          <label for="weight_num">Weight (in <?= $this->unit ?>)</label>
+          <input type="number" id="weight_num" class="form-control">
+        </div>
+
+        <div style="float: right; margin-top: 6px;">
+          <button class="btn btn-success" id="btn_post">Post</button>
+        </div>
+      </form>
+
+      <div style="clear: both;"></div>
+
+  </div>
+<script>
+$(function(){
+  $("#btn_post").click(function(){
+    $("#btn_post").addClass("loading disabled");
+
+    $.post("/weight", {
+      weight_num: $("#weight_num").val()
+    }, function(response){
+      if(response.location != false) {
+
+        $("#test_success").removeClass('hidden');
+        $("#test_error").addClass('hidden');
+        $("#post_href").attr("href", response.location);
+
+        window.location = response.location;
+      } else {
+        $("#test_success").addClass('hidden');
+        $("#test_error").removeClass('hidden');
+        if(response.error_details) {
+          $("#test_error").text(response.error_details);
+        }
+        $("#btn_post").removeClass("loading disabled");
+      }
+
+    });
+    return false;
+  });
+});
+</script>

--- a/views/settings.php
+++ b/views/settings.php
@@ -61,6 +61,17 @@
     </tr>
   </table>
 
+  <h3>Post Format Settings</h3>
+  <table class="table table-condensed" width="100%">
+    <tr>
+      <td>Weight Unit</td>
+      <td width="160">
+        <div style="margin-bottom:4px;"><input type="text" id="weight-unit" value="<?= $this->user->weight_unit ?>" class="form-control"></div>
+        <div><input type="button" class="btn btn-primary" value="Save" id="save-weight-unit"></div>
+      </td>
+      <td>The unit to be used for <a href="/weight">weight posts</a>.</td>
+    </tr>
+  </table>
 
   <h3>Syndication Targets</h3>
 
@@ -182,6 +193,11 @@ $(function(){
   });
 
 
+  $("#save-weight-unit").click(function(){
+    $.post("/settings/save", {
+      weight_unit: $("#weight-unit").val()
+    });
+  });
 
 });
 


### PR DESCRIPTION
The simplest solution I could find to add a new view for posting weight, and a new setting for the weight unit.

Weight unit will accept any string and defaults to `kg`.

The following JSON will be posted to the Micropub endpoint:

```json
{
    "type": [
        "h-entry"
    ],
    "properties": {
        "weight": [
            {
                "type": [
                    "h-measure"
                ],
                "properties": {
                    "num": [
                        "82.0"
                    ],
                    "unit": [
                        "kg"
                    ]
                }
            }
        ]
    }
}
```

[As seen on Sink](https://sink.zegnat.net/1SRVgnsMEzj2FZ3YxAxtoxGG2UM).