### PR TITLE
Use parse_headers for media endpoint uploads

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -120,8 +120,8 @@ function micropub_media_post_for_user(&$user, $file) {
   $r = micropub_post($user->micropub_media_endpoint, [], $user->micropub_access_token, $file, true, 'file');
 
   // Check the response and look for a "Location" header containing the URL
-  if($r['response'] && preg_match('/Location: (.+)/', $r['response'], $match)) {
-    $r['location'] = trim($match[1]);
+  if($r['headers'] && $r['headers']['Location']) {
+    $r['location'] = $r['headers']['Location'];
   } else {
     $r['location'] = false;
   }


### PR DESCRIPTION
`micropub_media_post_for_user` makes a case-sensitive search for the
Location header, which fails if the location header is all lowercase (or anything other than `Location`).

This change uses the `headers` fields, introduced in
2b98a4548e82f1133bf62918b0106ab99a21fa29a, to find the Location header,
regardless of case.