### PR TITLE
Track token expiration

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -175,6 +175,10 @@ $app->get('/auth/callback', function() use($app) {
     $user->token_endpoint = $tokenEndpoint;
     $user->micropub_endpoint = $micropubEndpoint;
     $user->micropub_access_token = $token['response']['access_token'];
+    if(is_numeric($token['response']['expires_in'])) {
+      $expiration = time() + $token['response']['expires_in'];
+      $user->micropub_token_expiration = date('Y-m-d H:i:s', $expiration);
+    }
     $user->micropub_scope = $token['response']['scope'];
     $user->micropub_response = $token['raw_response'];
     $user->save();
@@ -236,6 +240,7 @@ $app->post('/auth/reset', function() use($app) {
     $user->micropub_media_endpoint = '';
     $user->micropub_scope = '';
     $user->micropub_access_token = '';
+    $user->micropub_token_expiration = '';
     $user->syndication_targets = '';
     $user->supported_post_types = '';
     $user->save();

--- a/controllers/controllers.php
+++ b/controllers/controllers.php
@@ -30,7 +30,17 @@ function require_login(&$app, $redirect=true) {
       $app->redirect('/', 302);
     return false;
   } else {
-    return ORM::for_table('users')->find_one($_SESSION['user_id']);
+    $user = ORM::for_table('users')->find_one($_SESSION['user_id']);
+    if(isset($user->micropub_token_expiration)) {
+      $now = new DateTime();
+      $expiration = new DateTime($user->micropub_token_expiration);
+      if($now > $expiration) {
+        header('X-Error: TokenExpired');
+        $app->redirect('/auth/start?'.http_build_query(array('me' => $user->url)), 302);
+        return false;
+      }
+    }
+    return $user;
   }
 }
 

--- a/schema/migrations/0013.sql
+++ b/schema/migrations/0013.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN `micropub_token_expiration` datetime DEFAULT NULL;

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -6,6 +6,7 @@ CREATE TABLE `users` (
   `micropub_endpoint` varchar(255) DEFAULT NULL,
   `micropub_media_endpoint` varchar(255) DEFAULT NULL,
   `micropub_access_token` text,
+  `micropub_token_expiration` datetime DEFAULT NULL,
   `micropub_scope` varchar(255) DEFAULT NULL,
   `micropub_response` text,
   `micropub_slug_field` varchar(255) NOT NULL DEFAULT 'mp-slug',

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -6,6 +6,7 @@ CREATE TABLE users (
   micropub_endpoint TEXT,
   micropub_media_endpoint TEXT,
   micropub_access_token TEXT,
+  micropub_token_expiration datetime,
   micropub_scope TEXT,
   micropub_response TEXT,
   micropub_slug_field TEXT default 'mp-slug',


### PR DESCRIPTION
Force reauthentication after the token expires.

This doesn't exactly solve the refresh token gap (aaronpk/Quill#145), but it's an improvement over the current behavior, where everything quietly fails after the token expires. 